### PR TITLE
Target API Level 16 (Android 4.1, Jelly Bean)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="8"/>
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="16"/>
     <uses-feature android:glEsVersion="0x00020000"/>
     <uses-feature android:name="android.software.live_wallpaper" />
 

--- a/project.properties
+++ b/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}\tools\proguard\proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-8
+target=android-16


### PR DESCRIPTION
targetSdkVersion indicates that everything is tested and working with
the specified API Level. At the time of this commit, API Level 16 is
the latest and greatest provided by the Android SDK.

Updating this removes the extra step a newbie will have to take after downloading the latest SDK and tool chain. As far as I can tell amongst my devices (the oldest being 2.3, Gingerbread), builds will still work fine with older versions of Android (hooray for backwards-compatible SDK).
