### PR TITLE
BIND_WALLPAPER removal from settings activity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -34,8 +34,7 @@
         <activity
             android:name=".Settings"
             android:exported="true"
-            android:label="@string/app_name"
-            android:permission="android.permission.BIND_WALLPAPER" >
+            android:label="@string/app_name" >
             <intent-filter>
                 <category android:name="android.intent.category.PREFERENCE" />
             </intent-filter>


### PR DESCRIPTION
BIND_WALLPAPER should not be on the activity, only the service. It blows up using the Android 2.3 "configure.." menu option on my device.
